### PR TITLE
Implement config parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,44 +3,44 @@ use std::collections::HashMap;
 use std::error;
 use std::fmt;
 use std::io;
-use std::io::Read;
 use std::path::Path;
 use yaml_rust::{Yaml, YamlLoader};
 
 #[derive(Debug)]
 pub enum ConfigError {
-  Io(io::Error),
-  Yaml(yaml_rust::ScanError),
+    Io(io::Error),
+    Yaml(yaml_rust::ScanError),
 }
 
 impl fmt::Display for ConfigError {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    match *self {
-      // Underlying errors already impl `Display`, so we defer to
-      // their implementations.
-      ConfigError::Io(ref err) => write!(f, "MITRE: IO error: {}", err),
-      ConfigError::Yaml(ref err) => write!(f, "MITRE: YAML error: {}", err),
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            // Underlying errors already impl `Display`, so we defer to
+            // their implementations.
+            ConfigError::Io(ref err) => write!(f, "MITRE: IO error: {}", err),
+            ConfigError::Yaml(ref err) => write!(f, "MITRE: YAML error: {}", err),
+        }
     }
-  }
 }
 
 impl error::Error for ConfigError {
-  fn cause(&self) -> Option<&dyn error::Error> {
-    match *self {
-      // N.B. implicitly cast `err` from their concrete
-      // types (either `&io::Error` or `&num::ParseIntError`)
-      // to a trait object `&Error`. This works because both error types
-      // implement `Error`.
-      ConfigError::Io(ref err) => Some(err),
-      ConfigError::Yaml(ref err) => Some(err),
+    fn cause(&self) -> Option<&dyn error::Error> {
+        match *self {
+            // N.B. implicitly cast `err` from their concrete
+            // types (either `&io::Error` or `&num::ParseIntError`)
+            // to a trait object `&Error`. This works because both error types
+            // implement `Error`.
+            ConfigError::Io(ref err) => Some(err),
+            ConfigError::Yaml(ref err) => Some(err),
+        }
     }
-  }
 }
 
 impl From<io::Error> for ConfigError {
-  fn from(err: io::Error) -> ConfigError {
-    ConfigError::Io(err)
-  }
+    fn from(err: io::Error) -> ConfigError {
+        ConfigError::Io(err)
+    }
+
 }
 
 // impl From<serde_yaml::Error> for ConfigError {
@@ -50,9 +50,9 @@ impl From<io::Error> for ConfigError {
 // }
 
 impl From<yaml_rust::ScanError> for ConfigError {
-  fn from(err: yaml_rust::ScanError) -> ConfigError {
-    ConfigError::Yaml(err)
-  }
+    fn from(err: yaml_rust::ScanError) -> ConfigError {
+        ConfigError::Yaml(err)
+    }
 }
 
 //
@@ -60,69 +60,135 @@ impl From<yaml_rust::ScanError> for ConfigError {
 //
 #[derive(Debug)]
 pub struct Configuration {
-  // Runner is not optional, but we need to option it here to maintain
-  // serde::Deserialize compatibility
-  pub _runner: Option<String>,
+    // Runner is not optional, but we need to option it here to maintain
+    // serde::Deserialize compatibility
+    pub _runner: Option<String>,
 
-  pub database: Option<String>, // used by MariaDB, MySQL, PostgreSQL runners
+    pub database: Option<String>, // used by MariaDB, MySQL, PostgreSQL runners
 
-  pub index: Option<String>, // used by ElasticSearch
+    pub index: Option<String>, // used by ElasticSearch
 
-  pub database_number: Option<u8>, // used by Redis runner
+    pub database_number: Option<u8>, // used by Redis runner
 
-  // Maybe this should have another name, we also would
-  // probably accept IPs or anything resolveable here.
-  pub ip_or_hostname: Option<String>, // used by cURL, MySQL, Redis, MySQL, PostgreSQL, ElasticSearch
+    // Maybe this should have another name, we also would
+    // probably accept IPs or anything resolveable here.
+    pub ip_or_hostname: Option<String>, // used by cURL, MySQL, Redis, MySQL, PostgreSQL, ElasticSearch
 
-  // Max value for port on linux comes from `cat /proc/sys/net/ipv4/ip_local_port_range`
-  // u16 should be enough for most people most of the time.
-  pub port: Option<u16>, // used by cURL, MySQL, Redis, MySQL, PostgreSQL, ElasticSearch
+    // Max value for port on linux comes from `cat /proc/sys/net/ipv4/ip_local_port_range`
+    // u16 should be enough for most people most of the time.
+    pub port: Option<u16>, // used by cURL, MySQL, Redis, MySQL, PostgreSQL, ElasticSearch
 
-  pub username: Option<String>,
-  pub password: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+fn get_string(yaml: &yaml_rust::Yaml, search_key: String) -> Option<String> {
+    println!("\n\n\n yaml: {:?} \n\t search_key: {:?}", yaml, search_key);
+    let mut result: Option<String> = None;
+
+    match yaml {
+        Yaml::Hash(ref map) => {
+            for (k, v) in map {
+                if as_string(k).eq(&search_key) {
+                    match v {
+                        Yaml::String(value) => result = Some(value.to_string()),
+                        _ => (), // value at search_key is not a string
+                    }
+                }
+            }
+        }
+        _ => (), // Yaml is no hash
+    };
+    result
+}
+
+fn as_string(yaml: &yaml_rust::Yaml) -> String {
+    match yaml {
+        yaml_rust::Yaml::String(yaml) => yaml.to_owned(),
+        _ => String::from("")
+    }
 }
 
 // TODO: validate at least one `mitre` config with a compatible runner in the HashMap<String,...>
 
 pub fn from_file(p: &Path) -> Result<HashMap<String, Configuration>, ConfigError> {
-  // TODO: File doesn't exist
-  // TODO: File isn't a file
-  // TODO: File isn't readable
-  // TODO: File isn't YAML
-  // TODO: File isn't _valid_ YAML
-  let s = std::fs::read_to_string(p)?;
-  let yaml_docs = YamlLoader::load_from_str(&s)?;
+    // TODO: File doesn't exist
+    // TODO: File isn't a file
+    // TODO: File isn't readable
+    // TODO: File isn't YAML
+    // TODO: File isn't _valid_ YAML
+    let s = std::fs::read_to_string(p)?;
+    let yaml_docs = YamlLoader::load_from_str(&s)?;
 
-  let hm: HashMap<String, Configuration> = HashMap::new();
-  for yaml in yaml_docs {
-    match yaml {
-      Yaml::Hash(ref map) => {
-        for (k, v) in map {
-          println!("k: {:?} === v: {:?}", k, v);
+    let mut hm: HashMap<String, Configuration> = HashMap::new();
+    for yaml in yaml_docs {
+        match yaml {
+            Yaml::Hash(ref map) => {
+                for (k, v) in map {
+                    match v {
+                        Yaml::Hash(ref value) => {
+                            let strange_element = value.iter().next(); // shows up as <<
+                            let config_value = strange_element.unwrap().1;
+                            println!("k: {:?} === v: {:?}", k, config_value);
+                            let c = Configuration {
+                                _runner: get_string(config_value, String::from("_runner")),
+                                database: get_string(config_value, String::from("database")),
+                                index: get_string(config_value, String::from("index")),
+                                database_number: Some(1),
+                                ip_or_hostname: get_string(config_value, String::from("ip_or_hostname")),
+                                port: Some(1234),
+                                username: get_string(config_value, String::from("username")),
+                                password: get_string(config_value, String::from("password")),
+                            };
+                            hm.insert(as_string(k), c);
+                        }
+                        _ => ()
+                    }
+                }
+            }
+            _ => warn!("unexpected type at top level of YAML"),
         }
-      }
-      _ => warn!("unexpected type at top level of YAML"),
+
+        // println!(">>> yaml is {:?}", yaml);
+        // let _ = yaml.into_iter().map(|item| {
+        //   println!("item: {:?}", item);
+        // });
+        // println!("after iter");
+        // for key in yaml_docs[yaml].into_iter() {
+        //   println!("a yaml {:?}", yaml);
+        // }
     }
-    // println!(">>> yaml is {:?}", yaml);
-    // let _ = yaml.into_iter().map(|item| {
-    //   println!("item: {:?}", item);
-    // });
-    println!("after iter");
-    // for key in yaml_docs[yaml].into_iter() {
-    //   println!("a yaml {:?}", yaml);
-    // }
-  }
-  // let hm: HashMap<String, Configuration> = serde_yaml::from_reader(f)?;
-  // println!("Read YAML string: {:?}", hm);
-  Ok(hm) // Ok(serde_yaml::from_reader(f))
+    // let hm: HashMap<String, Configuration> = serde_yaml::from_reader(f)?;
+    // println!("Read YAML string: {:?}", hm);
+    Ok(hm) // Ok(serde_yaml::from_reader(f))
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use yaml_rust::YamlLoader;
 
-  // use super::*;
+    // unsupportted runner
+    // use of reserved word out of place
+    // dot separated parts not at end of filename
 
-  // unsupportted runner
-  // use of reserved word out of place
-  // dot separated parts not at end of filename
+    #[test]
+    fn get_string_gets_string() -> Result<(), yaml_rust::ScanError> {
+        let yaml_docs = YamlLoader::load_from_str(
+            "
+key: bestValue
+  ",
+        )?;
+        let doc = yaml_docs.first();
+        let result = match doc {
+            Some(document) => get_string(document, String::from("key")),
+            _ => None,
+        };
+
+        assert_eq!(
+            result.or(Some(String::from("error"))),
+            Some(String::from("bestValue"))
+        );
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,121 +18,122 @@ use runner::mariadb::MariaDB;
 use runner::Runner;
 
 fn main() {
-  env_logger::init();
+    env_logger::init();
 
-  let m = App::new("mitre")
-    .version("0.1")
-    .author("Lee Hambley <lee.hambley@gmail.com>")
-    .about("CLI runner for migrations")
-    .subcommand(
-      App::new("reserved-words")
-        .about("utilties for reserved words")
-        .subcommand(App::new("ls").about("list reserved words")),
-    )
-    .subcommand(
-      App::new("show-config")
-        .about("for showing config file")
-        .arg(
-          Arg::with_name("config_file")
-            .long("config")
-            .short('c')
-            .takes_value(true)
-            .value_name("CONFIG FILE")
-            .about("The configuration file to use, no default"),
-        ),
-    )
-    .subcommand(
-      App::new("show-migrations")
-        .about("for migrations")
-        .arg(
-          Arg::with_name("config_file")
-            .long("config")
-            .short('c')
-            .takes_value(true)
-            .value_name("CONFIG FILE")
-            .about("The configuration file to use"),
+    let m = App::new("mitre")
+        .version("0.1")
+        .author("Lee Hambley <lee.hambley@gmail.com>")
+        .about("CLI runner for migrations")
+        .subcommand(
+            App::new("reserved-words")
+                .about("utilties for reserved words")
+                .subcommand(App::new("ls").about("list reserved words")),
         )
-        .arg(
-          Arg::with_name("directory")
-            .long("directory")
-            .short('d')
-            .takes_value(true)
-            .value_name("MIGRATION DIR")
-            .about("The directory to use"),
-        ),
-    )
-    .get_matches();
+        .subcommand(
+            App::new("show-config")
+                .about("for showing config file")
+                .arg(
+                    Arg::with_name("config_file")
+                        .long("config")
+                        .short('c')
+                        .takes_value(true)
+                        .value_name("CONFIG FILE")
+                        .about("The configuration file to use, no default"),
+                ),
+        )
+        .subcommand(
+            App::new("show-migrations")
+                .about("for migrations")
+                .arg(
+                    Arg::with_name("config_file")
+                        .long("config")
+                        .short('c')
+                        .takes_value(true)
+                        .value_name("CONFIG FILE")
+                        .about("The configuration file to use"),
+                )
+                .arg(
+                    Arg::with_name("directory")
+                        .long("directory")
+                        .short('d')
+                        .takes_value(true)
+                        .value_name("MIGRATION DIR")
+                        .about("The directory to use"),
+                ),
+        )
+        .get_matches();
 
-  match m.subcommand_name() {
-    Some("reserved-words") => {
-      let mut table = Table::new();
+    match m.subcommand_name() {
+        Some("reserved-words") => {
+            let mut table = Table::new();
 
-      table.add_row(row!["Word", "Kind", "Reason"]);
+            table.add_row(row!["Word", "Kind", "Reason"]);
 
-      reserved::words().iter().for_each(|word| {
-        table.add_row(Row::new(vec![
-          Cell::new(word.word).style_spec("bFy"),
-          Cell::new(&word.kind.to_string()).style_spec("Fb"),
-          Cell::new(word.reason),
-        ]));
-      });
-      table.printstd();
+            reserved::words().iter().for_each(|word| {
+                table.add_row(Row::new(vec![
+                    Cell::new(word.word).style_spec("bFy"),
+                    Cell::new(&word.kind.to_string()).style_spec("Fb"),
+                    Cell::new(word.reason),
+                ]));
+            });
+            table.printstd();
+        }
+
+        Some("show-config") => {
+            if let Some(ref matches) = m.subcommand_matches("show-config") {
+                assert!(matches.is_present("config_file"));
+                let path = Path::new(matches.value_of("config_file").unwrap());
+                match config::from_file(path) {
+                    Ok(c) => {
+                        println!("loading config succeeded {:?}", c);
+                        let mitre_config = c.get("es-mariadb").expect("must provide mitre config");
+                        let mdb = MariaDB::new(mitre_config);
+                        match mdb {
+                            Ok(mut mmmdb) => {
+                                println!("bootstrap {:?}", mmmdb.bootstrap());
+                            }
+                            Err(e) => {
+                                println!("error connecting/reading config for mariadb {:?}", e);
+                                std::process::exit(123);
+                            }
+                        };
+                    }
+                    Err(e) => {
+                        println!("error loading config: {:?}", e)
+                    }
+                };
+                println!("using {:?}", path);
+            }
+            println!("wat, no config");
+        }
+
+        Some("show-migrations") => {
+            info!("showing migrations");
+            if let Some(ref matches) = m.subcommand_matches("show-migrations") {
+                assert!(matches.is_present("directory"));
+                let path = Path::new(matches.value_of("directory").unwrap());
+                let migrations = match migrations::migrations(path) {
+                    Ok(m) => m,
+                    Err(_) => panic!("something happen"),
+                };
+
+                let mut table = Table::new();
+                table.add_row(row!["Filename", "Date/Time", "Flags"]);
+                migrations.iter().for_each(|migration| {
+                    eprintln!("{:?}", migration);
+                    table.add_row(Row::new(vec![
+                        Cell::new(migration.parsed.path.to_str().unwrap()).style_spec("bFy"),
+                        Cell::new(&format!("{}", migration.parsed.date_time.timestamp())[..])
+                            .style_spec("Fb"),
+                        Cell::new(&format!("{:?}", migration.parsed.flags)[..]),
+                    ]));
+                });
+                table.printstd();
+            }
+        }
+        Some("up") => {}   // up was used
+        Some("down") => {} // down was used
+        Some("redo") => {} // redo was used
+        _ => {}            // Either no subcommand or one not tested for...
     }
-
-    Some("show-config") => {
-      if let Some(ref matches) = m.subcommand_matches("show-config") {
-        assert!(matches.is_present("config_file"));
-        let path = Path::new(matches.value_of("config_file").unwrap());
-        match config::from_file(path) {
-          Ok(c) => {
-            println!("loading config succeeded {:?}", c);
-            let mitre_config = c.get("es-mariadb").expect("must provide mitre config");
-            let mdb = MariaDB::new(mitre_config);
-            match mdb {
-              Ok(mut mmmdb) => {
-                println!("bootstrap {:?}", mmmdb.bootstrap());
-              }
-              Err(e) => {
-                println!("error connecting/reading config for mariadb {:?}", e);
-                std::process::exit(123);
-              }
-            };
-          }
-          Err(e) => {
-            println!("error loading config: {:?}", e)
-          }
-        };
-        println!("using {:?}", path);
-      }
-      println!("wat, no config");
-    }
-
-    Some("show-migrations") => {
-      info!("showing migrations");
-      if let Some(ref matches) = m.subcommand_matches("show-migrations") {
-        assert!(matches.is_present("directory"));
-        let path = Path::new(matches.value_of("directory").unwrap());
-        let migrations = match migrations::migrations(path) {
-          Ok(m) => m,
-          Err(_) => panic!("something happen"),
-        };
-
-        let mut table = Table::new();
-        table.add_row(row!["Filename", "Date/Time", "Flags"]);
-        migrations.iter().for_each(|migration| {
-          eprintln!("{:?}", migration);
-          table.add_row(Row::new(vec![
-            Cell::new(migration.parsed.path.to_str().unwrap()).style_spec("bFy"),
-            Cell::new(&format!("{}", migration.parsed.date_time.timestamp())[..]).style_spec("Fb"),
-            Cell::new(&format!("{:?}", migration.parsed.flags)[..]),
-          ]));
-        });
-        table.printstd();
-      }
-    }
-    Some("up") => {}   // up was used
-    Some("down") => {} // down was used
-    Some("redo") => {} // redo was used
-    _ => {}            // Either no subcommand or one not tested for...
-  }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,13 +2,13 @@ pub mod mariadb;
 use crate::config::Configuration;
 
 pub trait Runner {
-  type Error;
+    type Error;
 
-  fn new(config: &Configuration) -> Result<Self, Self::Error>
-  where
-    Self: Sized;
+    fn new(config: &Configuration) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
 
-  fn bootstrap(&mut self) -> Result<(), Self::Error>
-  where
-    Self: Sized;
+    fn bootstrap(&mut self) -> Result<(), Self::Error>
+    where
+        Self: Sized;
 }

--- a/src/runner/mariadb.rs
+++ b/src/runner/mariadb.rs
@@ -3,40 +3,44 @@ use mysql::{Conn, OptsBuilder};
 
 #[derive(Debug)]
 pub struct MariaDB {
-  conn: Conn,
+    conn: Conn,
 }
 
 #[derive(Debug)]
 pub enum MariaDBError {
-  MySQL(mysql::Error),
-  PingFailed(),
+    MySQL(mysql::Error),
+    PingFailed(),
 }
 
 impl From<mysql::Error> for MariaDBError {
-  fn from(err: mysql::Error) -> MariaDBError {
-    MariaDBError::MySQL(err)
-  }
+    fn from(err: mysql::Error) -> MariaDBError {
+        MariaDBError::MySQL(err)
+    }
+}
+
+fn ensure_connectivity(db: &mut MariaDB) -> Result<(), MariaDBError> {
+    return match db.conn.ping() {
+        true => Ok(()),
+        false => Err(MariaDBError::PingFailed()),
+    };
 }
 
 impl super::Runner for MariaDB {
-  type Error = MariaDBError;
-  fn new(config: &Configuration) -> Result<MariaDB, MariaDBError> {
-    println!("using config {:?}", config);
-    let opts = OptsBuilder::new()
-      .ip_or_hostname(config.ip_or_hostname.clone())
-      .user(config.username.clone())
-      .db_name(config.database.clone())
-      .pass(config.password.clone());
-    println!("Connection options are: {:?}", opts);
-    let conn = Conn::new(opts)?;
-    return Ok(MariaDB { conn });
-  }
+    type Error = MariaDBError;
+    fn new(config: &Configuration) -> Result<MariaDB, MariaDBError> {
+        println!("using config {:?}", config);
+        let opts = OptsBuilder::new()
+            .ip_or_hostname(config.ip_or_hostname.clone())
+            .user(config.username.clone())
+            .db_name(config.database.clone())
+            .pass(config.password.clone());
+        println!("Connection options are: {:?}", opts);
+        let conn = Conn::new(opts)?;
+        return Ok(MariaDB { conn });
+    }
 
-  // https://docs.rs/mysql/20.1.0/mysql/struct.Conn.html
-  fn bootstrap(&mut self) -> Result<(), MariaDBError> {
-    return match self.conn.ping() {
-      true => Ok(()),
-      false => Err(MariaDBError::PingFailed()),
-    };
-  }
+    // https://docs.rs/mysql/20.1.0/mysql/struct.Conn.html
+    fn bootstrap(&mut self) -> Result<(), MariaDBError> {
+        ensure_connectivity(self)
+    }
 }


### PR DESCRIPTION
The yaml parser sets the value of a hash as 
```json
{
  "<<": {
    // actual content
   }
}
```

So there is a little bit of mumbo jumbo to get around that. 

### Testing
```
> cargo run  -- show-config -c ./test/fixtures/example-1-simple-mixed-migrations/config.yml
...
...
...
loading config succeeded {"es-docker": Configuration { _runner: None, database: None, index: None, database_number: Some(1), ip_or_hostname: None, port: Some(1234), username: None, password: None }, "mitre": Configuration { _runner: Some("mysql"), database: Some("mitre"), index: None, database_number: Some(1), ip_or_hostname: Some("127.0.0.1"), port: Some(1234), username: Some("root"), password: Some("example") }, "es-mariadb": Configuration { _runner: None, database: None, index: None, database_number: Some(1), ip_or_hostname: None, port: Some(1234), username: None, password: None }}
```

It seems like the config is only parsed for mitre, maybe because it is a reference, we will need to find out, but I wanted to limit the PR in size and time