### PR TITLE
Improve error handling in config loading, and support u8/u16 config values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::GetStringError() => write!(
                 f,
-                "MITRE: YAML error: get_string() passed-thru without match"
+                "Mitre: YAML error: get_string() passed-thru without match"
             ),
         }
     }

--- a/src/filename.rs
+++ b/src/filename.rs
@@ -180,6 +180,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn test_paths_with_no_runner_reserved_word_extension() {
         match parse(std::path::Path::new("./foo/20160708091011_bar.curl")) {
             Ok(_) => assert!(true),

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,9 +98,7 @@ fn main() {
                             }
                         };
                     }
-                    Err(e) => {
-                        println!("error loading config: {:?}", e)
-                    }
+                    Err(e) => println!("error loading config: {:?}", e),
                 };
                 println!("using {:?}", path);
             }


### PR DESCRIPTION
Quite a lot of smaller changes here, notably introduction of four new
error types, each one is self-explaining. The GetStringError I am not
_thrilled_ with, but it is needed to avoid an impossible case in the
dig_yaml_value function.

The get_string has been renamed to dig_ because somehow `get` feels
unsavory, anyway, it has been reimplemented to return a rust_yaml::YAML,
and to have dig_{string, u8, u16} wrappers around which do the
conversion/coercion to the appropriate types.

YAML's numeric type is implemented as i64 (range -9223372036854775808 to
9223372036854775807), since we have no use for negative port numbers in
general or database numbers in Redis, we need a `u__` and not an `i__`
anyway, and the 64 bit range is absurd anyway. Conversion to smaller
types *truncates* silently, which is a tiny big of a footgun but Redis
uses an `int` for the dbnum (-32,768 to 32,767 probably, depending on
platform) which is a bit wasteful, but no big deal.

Finally the call-sites of string_ (now dig_...) are updated to return an
`Result<Option<...` not an `Option` which means they can communicate the
new error reasons up the stack.

The `for_each` became `try_for_each` to allow us to bubble up the errors
and seemed to work OK.

The `Result<Option...>` may be redundant now; the `Option` types on the
`pub struct Configuration` were there to please Serde YAML anyway, but I
think I like the combination of Result and Option, the Result allows the
error handling (non-existent keys, etc) and the Option captures the fact
that the key may exist, but have no associated value.

Probably the error handling is not 100% dialed-in, I think with this
implementation a missing key, or a key with a missing value would result
in an error, not just a missing `Option<>` value in the config struct,
but I plan to explore this in a follow-up commit right after.

The tests were tweaked a bit, to have meaningful `Result<(), &'static
str>` errors, which makes them a bit more self-speaking, and I think
makes it clearer what is going on in case of failures.